### PR TITLE
Skyblock stuff

### DIFF
--- a/mappings/com/lunar/common/mod/skyblockaddons/BaitListMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/BaitListMod.mapping
@@ -1,1 +1,0 @@
-CLASS com/lunar/class_390 com/lunar/common/mod/skyblockaddons/BaitListMod

--- a/mappings/com/lunar/common/mod/skyblockaddons/FeatureJurisdiction.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/FeatureJurisdiction.mapping
@@ -1,0 +1,8 @@
+CLASS com/lunar/class_398 com/lunar/common/mod/skyblockaddons/FeatureJurisdiction
+	FIELD field_1423 SKYBLOCK_ONLY Lcom/lunar/class_398;
+	FIELD field_1425 name Ljava/lang/String;
+	FIELD field_1426 NEVER Lcom/lunar/class_398;
+	FIELD field_1427 ALWAYS Lcom/lunar/class_398;
+	METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+		ARG 3 name
+	METHOD method_1198 getName ()Ljava/lang/String;

--- a/mappings/com/lunar/common/mod/skyblockaddons/ShowsInOtherGames.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/ShowsInOtherGames.mapping
@@ -1,0 +1,3 @@
+CLASS com/lunar/class_395 com/lunar/common/mod/skyblockaddons/ShowsInOtherGames
+	FIELD field_1421 showInOtherGames Lcom/lunar/class_574;
+	METHOD method_1197 showsInOtherGames ()Lcom/lunar/class_574;

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyBlockAddonsDefensePercentageChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyBlockAddonsDefensePercentageChildMod.mapping
@@ -1,1 +1,5 @@
-CLASS com/lunar/class_387 com/lunar/common/mod/skyblockaddons/SkyBlockAddonsDefensePercentageChildMod
+CLASS com/lunar/class_387 com/lunar/common/mod/skyblockaddons/SkyblockAddonsDefensePercentageChildMod
+	FIELD field_1376 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1377 textColor Lcom/lunar/class_561;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyBlockAddonsHealthTextChild.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyBlockAddonsHealthTextChild.mapping
@@ -1,1 +1,0 @@
-CLASS com/lunar/class_392 com/lunar/common/mod/skyblockaddons/SkyBlockAddonsHealthTextChild

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyBlockAddonsManaTextChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyBlockAddonsManaTextChildMod.mapping
@@ -1,1 +1,5 @@
-CLASS com/lunar/class_389 com/lunar/common/mod/skyblockaddons/SkyBlockAddonsManaTextChildMod
+CLASS com/lunar/class_389 com/lunar/common/mod/skyblockaddons/SkyblockAddonsManaTextChildMod
+	FIELD field_1378 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1379 barColor Lcom/lunar/class_561;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsBaitListChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsBaitListChildMod.mapping
@@ -1,0 +1,6 @@
+CLASS com/lunar/class_390 com/lunar/common/mod/skyblockaddons/SkyblockAddonsBaitListChildMod
+	FIELD field_1380 textColor Lcom/lunar/class_561;
+	FIELD field_1381 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1382 baitNameToOrder Ljava/util/Map;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsBirchParkRainTimerChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsBirchParkRainTimerChildMod.mapping
@@ -1,0 +1,5 @@
+CLASS com/lunar/class_374 com/lunar/common/mod/skyblockaddons/SkyblockAddonsBirchParkRainTimerChildMod
+	FIELD field_1417 textColor Lcom/lunar/class_561;
+	FIELD field_1418 showTextShadow Lcom/lunar/class_574;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsDarkAuctionTimerChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsDarkAuctionTimerChildMod.mapping
@@ -1,0 +1,6 @@
+CLASS com/lunar/class_379 com/lunar/common/mod/skyblockaddons/SkyblockAddonsDarkAuctionTimerChildMod
+	FIELD field_1404 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1405 siriusIconResource Lcom/lunar/class_245;
+	FIELD field_1406 textColor Lcom/lunar/class_561;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsDefenseIconChild.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsDefenseIconChild.mapping
@@ -1,1 +1,0 @@
-CLASS com/lunar/class_381 com/lunar/common/mod/skyblockaddons/SkyblockAddonsDefenseIconChild

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsDefenseIconChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsDefenseIconChildMod.mapping
@@ -1,0 +1,7 @@
+CLASS com/lunar/class_381 com/lunar/common/mod/skyblockaddons/SkyblockAddonsDefenseIconChildMod
+	FIELD field_1393 iconsResource Lcom/lunar/class_245;
+	FIELD field_1394 defenseIconResource Lcom/lunar/class_245;
+	FIELD field_1395 useVanillaDefenseTexture Lcom/lunar/class_574;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba
+	METHOD method_1185 usesVanillaDefenseTexture ()Lcom/lunar/class_574;

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsDefenseTextChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsDefenseTextChildMod.mapping
@@ -1,0 +1,5 @@
+CLASS com/lunar/class_376 com/lunar/common/mod/skyblockaddons/SkyblockAddonsDefenseTextChildMod
+	FIELD field_1415 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1416 textColor Lcom/lunar/class_561;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsEndstoneProtectorChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsEndstoneProtectorChildMod.mapping
@@ -1,0 +1,7 @@
+CLASS com/lunar/class_377 com/lunar/common/mod/skyblockaddons/SkyblockAddonsEndstoneProtectorChildMod
+	FIELD field_1396 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1397 endermanGroupIconResource Lcom/lunar/class_245;
+	FIELD field_1398 ironGolemIconResource Lcom/lunar/class_245;
+	FIELD field_1399 textColor Lcom/lunar/class_561;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsHealthBarChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsHealthBarChildMod.mapping
@@ -1,0 +1,1 @@
+CLASS com/lunar/class_382 com/lunar/common/mod/skyblockaddons/SkyblockAddonsHealthBarChildMod

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsHealthTextChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsHealthTextChildMod.mapping
@@ -1,0 +1,5 @@
+CLASS com/lunar/class_392 com/lunar/common/mod/skyblockaddons/SkyblockAddonsHealthTextChildMod
+	FIELD field_1413 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1414 barColor Lcom/lunar/class_561;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsMagmaBossTimerChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsMagmaBossTimerChildMod.mapping
@@ -1,0 +1,6 @@
+CLASS com/lunar/class_386 com/lunar/common/mod/skyblockaddons/SkyblockAddonsMagmaBossTimerChildMod
+	FIELD field_1355 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1356 magmaBossIconResource Lcom/lunar/class_245;
+	FIELD field_1357 textColor Lcom/lunar/class_561;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsMod.mapping
@@ -1,5 +1,167 @@
 CLASS com/lunar/class_372 com/lunar/common/mod/skyblockaddons/SkyblockAddonsMod
-	CLASS class_1205
+	FIELD field_1240 alertOnSpecialZealot Lcom/lunar/class_574;
+	FIELD field_1242 stopBlinkingNightVision Lcom/lunar/class_574;
+	FIELD field_1243 zealotsPerEyeChildMod Lcom/lunar/class_383;
+	FIELD field_1245 disableEndermanTeleportationEffect Lcom/lunar/class_574;
+	FIELD field_1246 stopOpenProfileWhileHoldingBow Lcom/lunar/class_574;
+	FIELD field_1249 lockedSlots Ljava/util/Set;
+	FIELD field_1250 warningsChildMod Lcom/lunar/class_391;
+	FIELD field_1251 disableMagicalSoupMessages Lcom/lunar/class_574;
+	FIELD field_1252 summoningEyeCount I
+	FIELD field_1253 totalZealotKIlls I
+	FIELD field_1254 endstoneProtectorChildMod Lcom/lunar/class_377;
+	FIELD field_1255 sortItemEnchants Lcom/lunar/class_574;
+	FIELD field_1256 defensePercentageChildMod Lcom/lunar/class_387;
+	FIELD field_1257 supportExplosiveBowInZealotCounter Lcom/lunar/class_574;
+	FIELD field_1258 confirmDrop Lcom/lunar/class_558;
+	FIELD field_1259 enableBackpackPreview Lcom/lunar/class_574;
+	FIELD field_1261 skeletonHelmetChildMod Lcom/lunar/class_375;
+	FIELD field_1262 dropBlacklist Lcom/lunar/class_568;
+	FIELD field_1263 summoningEyeChildMod Lcom/lunar/class_388;
+	FIELD field_1265 manaTextChildMod Lcom/lunar/class_389;
+	FIELD field_1266 birchParkRainTimerChildMod Lcom/lunar/class_374;
+	FIELD field_1267 hidePetHealthBar Lcom/lunar/class_574;
+	FIELD field_1268 enableSlayerIndicator Lcom/lunar/class_574;
+	FIELD field_1269 showSkeletonHelmetBars Lcom/lunar/class_574;
+	FIELD field_1270 enableSlotLocking Lcom/lunar/class_574;
+	FIELD field_1271 tickerChargesChildMod Lcom/lunar/class_396;
+	FIELD field_1272 hidePlayersInLobbies Lcom/lunar/class_574;
+	FIELD field_1273 zealotTotalCounterChildMod Lcom/lunar/class_394;
+	FIELD field_1274 lockSlotKey Lcom/lunar/class_572;
+	FIELD field_1275 zealotKillsChildMod Lcom/lunar/class_380;
+	FIELD field_1277 backpackPreviewStyle Lcom/lunar/class_558;
+	FIELD field_1278 previewBackpacksOnAuctionHouse Lcom/lunar/class_574;
+	FIELD field_1279 manaBarChildMod Lcom/lunar/class_385;
+	FIELD field_1280 enableCakeBagPreview Lcom/lunar/class_574;
+	FIELD field_1281 baitListChildMod Lcom/lunar/class_390;
+	FIELD field_1282 disableTeleportPadMessages Lcom/lunar/class_574;
+	FIELD field_1283 hideVanillaFoodBar Lcom/lunar/class_574;
+	FIELD field_1285 zealotKillsSinceLastEye I
+	FIELD field_1286 replaceRomanNumerals Lcom/lunar/class_574;
+	FIELD field_1287 showBrokenDragonFragments Lcom/lunar/class_574;
+	FIELD field_1288 hideVanillaHealthBar Lcom/lunar/class_574;
+	FIELD field_1290 healthTextChildMod Lcom/lunar/class_392;
+	FIELD field_1291 recolorZealots Lcom/lunar/class_574;
+	FIELD field_1292 minimumHotbarItemRarity Lcom/lunar/class_558;
+	FIELD field_1293 enableFishingSoundIndicator Lcom/lunar/class_574;
+	FIELD field_1294 showCannotBreakBlockMessagesInPark Lcom/lunar/class_574;
+	FIELD field_1295 showEnchantmentsReforges Lcom/lunar/class_574;
+	FIELD field_1298 enableFancyWarpMenu Lcom/lunar/class_574;
+	FIELD field_1299 powerOrbChildMod Lcom/lunar/class_384;
+	FIELD field_1300 turnBowGreenWhenUsingToxicArrowPoison Lcom/lunar/class_574;
+	FIELD field_1301 colorEnderChestsInEnd Lcom/lunar/class_574;
+	FIELD field_1302 magmaBossTimerChildMod Lcom/lunar/class_386;
+	FIELD field_1303 speedTextChildMod Lcom/lunar/class_378;
+	FIELD field_1304 hideGreyEnchants Lcom/lunar/class_574;
+	FIELD field_1305 changeBarColorForPotions Lcom/lunar/class_574;
+	FIELD field_1306 stopDroppingSellingRareItems Lcom/lunar/class_574;
+	FIELD field_1307 darkAuctionTimerChildMod Lcom/lunar/class_379;
+	FIELD field_1308 dropWhitelist Lcom/lunar/class_568;
+	FIELD field_1309 backpackPreviewFreezeKey Lcom/lunar/class_572;
+	FIELD field_1310 zealotColor Lcom/lunar/class_561;
+	FIELD field_1311 colorBackpackInventories Lcom/lunar/class_574;
+	FIELD field_1313 hideSkeletonHelmetBones Lcom/lunar/class_574;
+	FIELD field_1314 displayCombatTimer Lcom/lunar/class_574;
+	FIELD field_1315 showItemAnvilUses Lcom/lunar/class_574;
+	FIELD field_1316 enderChestColorInEnd Lcom/lunar/class_561;
+	FIELD field_1319 hideSvenPupNametags Lcom/lunar/class_574;
+	FIELD field_1320 defenseIconChildMod Lcom/lunar/class_381;
+	FIELD field_1321 healthBarChildMod Lcom/lunar/class_382;
+	FIELD field_1322 showBackpackPreviewWhileHoldingShift Lcom/lunar/class_574;
+	FIELD field_1323 defenseTextChildMod Lcom/lunar/class_376;
+	FIELD field_1324 enableWarpMenuAdvancedMode Lcom/lunar/class_574;
+	FIELD field_1325 disableCursorResetBetweenInventories Lcom/lunar/class_574;
+	FIELD field_1327 skillExpDisplayChildMod Lcom/lunar/class_393;
+	METHOD method_1067 getZealotKillsChildMod ()Lcom/lunar/class_380;
+	METHOD method_1069 showsBackpackPreviewWhileHoldingShift ()Lcom/lunar/class_574;
+	METHOD method_1070 replacesRomanNumerals ()Lcom/lunar/class_574;
+	METHOD method_1071 getSummoningEyeCount ()I
+	METHOD method_1074 getEndstoneProtectorChildMod ()Lcom/lunar/class_377;
+	METHOD method_1075 disablesCursorResetBetweenInventories ()Lcom/lunar/class_574;
+	METHOD method_1076 getDropWhitelist ()Ljava/util/List;
+	METHOD method_1077 hidesVanillaFoodBar ()Lcom/lunar/class_574;
+	METHOD method_1078 getBackpackPreviewStyle ()Lcom/lunar/class_558;
+	METHOD method_1079 enablesSlayerIndicator ()Lcom/lunar/class_574;
+	METHOD method_1080 getBackpackPreviewFreezeKey ()Lcom/lunar/class_572;
+	METHOD method_1081 getLockSlotKey ()Lcom/lunar/class_572;
+	METHOD method_1082 getDefenseIconChildMod ()Lcom/lunar/class_381;
+	METHOD method_1084 hidesGreyEnchants ()Lcom/lunar/class_574;
+	METHOD method_1085 getDropBlacklist ()Ljava/util/List;
+	METHOD method_1086 getSpeedTextChildMod ()Lcom/lunar/class_378;
+	METHOD method_1087 getBirchParkRainTimerChildMod ()Lcom/lunar/class_374;
+	METHOD method_1088 confirmsDrop ()Lcom/lunar/class_558;
+	METHOD method_1089 getDefenseTextChildMod ()Lcom/lunar/class_376;
+	METHOD method_1090 getManaBarChildMod ()Lcom/lunar/class_385;
+	METHOD method_1091 enablesWarpMenuAdvancedMode ()Lcom/lunar/class_574;
+	METHOD method_1092 getLockedSlots ()Ljava/util/Set;
+	METHOD method_1094 getMagmaBossTimerChildMod ()Lcom/lunar/class_386;
+	METHOD method_1095 getHealthBarChildMod ()Lcom/lunar/class_382;
+	METHOD method_1096 getSkyblockAddonsDarkAuctionTimerChildMod ()Lcom/lunar/class_379;
+	METHOD method_1097 getZealotsPerEyeChildMod ()Lcom/lunar/class_383;
+	METHOD method_1099 stopsBlinkingNightVision ()Lcom/lunar/class_574;
+	METHOD method_1100 previewsBackpacks ()Lcom/lunar/class_574;
+	METHOD method_1101 setZealotKillsSinceLastEye (I)V
+		ARG 1 kills
+	METHOD method_1103 getZealotTotalCounterChildMod ()Lcom/lunar/class_394;
+	METHOD method_1105 getZealotColor ()Lcom/lunar/class_561;
+	METHOD method_1106 getMinimumHotbarItemRarity ()Lcom/lunar/class_558;
+	METHOD method_1107 hidesSvenPupNametags ()Lcom/lunar/class_574;
+	METHOD method_1109 alertsOnSpecialZealot ()Lcom/lunar/class_574;
+	METHOD method_1111 hidesSkeletonHeletBones ()Lcom/lunar/class_574;
+	METHOD method_1112 enablesFishingSoundIndicator ()Lcom/lunar/class_574;
+	METHOD method_1114 getEnderChestColorInEnd ()Lcom/lunar/class_561;
+	METHOD method_1115 hidesPetHealthBar ()Lcom/lunar/class_574;
+	METHOD method_1116 showsEnchantmentsReforges ()Lcom/lunar/class_574;
+	METHOD method_1117 displaysCombatTimer ()Lcom/lunar/class_574;
+	METHOD method_1118 getWarningsChildMod ()Lcom/lunar/class_391;
+	METHOD method_1120 disablesEndermanTeleportationEffect ()Lcom/lunar/class_574;
+	METHOD method_1121 getTotalZealotKills ()I
+	METHOD method_1122 colorsBackpackInventories ()Lcom/lunar/class_574;
+	METHOD method_1123 enablesFancyWarpMenu ()Lcom/lunar/class_574;
+	METHOD method_1124 showsSkeletonHelmetBars ()Lcom/lunar/class_574;
+	METHOD method_1125 changesBarColorForPotions ()Lcom/lunar/class_574;
+	METHOD method_1127 previewsBackpacksOnAuctionHouse ()Lcom/lunar/class_574;
+	METHOD method_1128 getPowerOrbChildMod ()Lcom/lunar/class_384;
+	METHOD method_1129 getSummoningEyeCounterChildMod ()Lcom/lunar/class_388;
+	METHOD method_1130 disablesMagicalSoupMessages ()Lcom/lunar/class_574;
+	METHOD method_1131 setSummoningEyeCount (I)V
+		ARG 1 count
+	METHOD method_1132 getSkeletonHelmetChildMod ()Lcom/lunar/class_375;
+	METHOD method_1133 turnsBowGreenWhenUsingToxicArrowPoison ()Lcom/lunar/class_574;
+	METHOD method_1134 stopsOpenProfileWhileHoldingBow ()Lcom/lunar/class_574;
+	METHOD method_1135 getDefensePercentageChildMod ()Lcom/lunar/class_387;
+	METHOD method_1137 enablesSlotLocking ()Lcom/lunar/class_574;
+	METHOD method_1138 getZealotKillsSinceLastEye ()I
+	METHOD method_1139 recolorsZealots ()Lcom/lunar/class_574;
+	METHOD method_1140 supportsExplosiveBowInZealotCounter ()Lcom/lunar/class_574;
+	METHOD method_1141 colorsEnderChestsInEnd ()Lcom/lunar/class_574;
+	METHOD method_1142 showsBrokenDragonFragments ()Lcom/lunar/class_574;
+	METHOD method_1144 enablesCakeBagPreview ()Lcom/lunar/class_574;
+	METHOD method_1146 getTickerChargesChildMod ()Lcom/lunar/class_396;
+	METHOD method_1147 getSkillExpDisplayChildMod ()Lcom/lunar/class_393;
+	METHOD method_1148 hidesPlayersInLobbies ()Lcom/lunar/class_574;
+	METHOD method_1149 sortsItemEnchants ()Lcom/lunar/class_574;
+	METHOD method_1150 showCannotBreakBlockMessagesInPark ()Lcom/lunar/class_574;
+	METHOD method_1151 getHealthTextChildMod ()Lcom/lunar/class_392;
+	METHOD method_1152 hidesVanillaHealthBar ()Lcom/lunar/class_574;
+	METHOD method_1153 setTotalZealotKills (I)V
+		ARG 1 kills
+	METHOD method_1154 getManaTextChildMod ()Lcom/lunar/class_389;
+	METHOD method_1155 getBaitListChildMod ()Lcom/lunar/class_390;
+	METHOD method_1156 disablesTeleportPadMessages ()Lcom/lunar/class_574;
+	METHOD method_1158 showsItemAnvilUses ()Lcom/lunar/class_574;
+	METHOD method_1159 (Lcom/google/gson/JsonElement;)V
+		ARG 1 slot
+	METHOD method_1163 stopsDroppingSellingRareItems ()Lcom/lunar/class_574;
+	CLASS class_1204 CraftingPattern
+		FIELD field_1329 THREE Lcom/lunar/class_372$class_1204;
+		FIELD field_1330 name Ljava/lang/String;
+		FIELD field_1331 SIX Lcom/lunar/class_372$class_1204;
+		FIELD field_1332 FIVE Lcom/lunar/class_372$class_1204;
+		FIELD field_1333 FREE Lcom/lunar/class_372$class_1204;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 name
+	CLASS class_1205 SkyblockRarity
 		FIELD field_1335 MYTHIC Lcom/lunar/class_372$class_1205;
 		FIELD field_1336 UNCOMMON Lcom/lunar/class_372$class_1205;
 		FIELD field_1337 LEGENDARY Lcom/lunar/class_372$class_1205;
@@ -7,4 +169,14 @@ CLASS com/lunar/class_372 com/lunar/common/mod/skyblockaddons/SkyblockAddonsMod
 		FIELD field_1339 EPIC Lcom/lunar/class_372$class_1205;
 		FIELD field_1340 SPECIAL Lcom/lunar/class_372$class_1205;
 		FIELD field_1341 RARE Lcom/lunar/class_372$class_1205;
+		FIELD field_1342 name Ljava/lang/String;
 		FIELD field_1343 COMMON Lcom/lunar/class_372$class_1205;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 name
+		METHOD method_1164 getName ()Ljava/lang/String;
+	CLASS class_1206 SkyblockAddonsDisplayType
+		FIELD field_1344 COMPACT Lcom/lunar/class_372$class_1206;
+		FIELD field_1346 name Ljava/lang/String;
+		FIELD field_1347 REGULAR Lcom/lunar/class_372$class_1206;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 name

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsPowerOrbChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsPowerOrbChildMod.mapping
@@ -1,0 +1,7 @@
+CLASS com/lunar/class_384 com/lunar/common/mod/skyblockaddons/SkyblockAddonsPowerOrbChildMod
+	FIELD field_1409 detailedMode Lcom/lunar/class_574;
+	FIELD field_1410 textColor Lcom/lunar/class_561;
+	FIELD field_1411 timerFormat Ljava/text/DecimalFormat;
+	FIELD field_1412 showTextShadow Lcom/lunar/class_574;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsSkeletonHelmetChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsSkeletonHelmetChildMod.mapping
@@ -1,0 +1,3 @@
+CLASS com/lunar/class_375 com/lunar/common/mod/skyblockaddons/SkyblockAddonsSkeletonHelmetChildMod
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsSkillExpDisplayChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsSkillExpDisplayChildMod.mapping
@@ -1,0 +1,5 @@
+CLASS com/lunar/class_393 com/lunar/common/mod/skyblockaddons/SkyblockAddonsSkillExpDisplayChildMod
+	FIELD field_1402 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1403 textColor Lcom/lunar/class_561;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsSpeedTextChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsSpeedTextChildMod.mapping
@@ -1,0 +1,5 @@
+CLASS com/lunar/class_378 com/lunar/common/mod/skyblockaddons/SkyblockAddonsSpeedTextChildMod
+	FIELD field_1400 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1401 textColor Lcom/lunar/class_561;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsSummoningEyeCounterChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsSummoningEyeCounterChildMod.mapping
@@ -1,0 +1,6 @@
+CLASS com/lunar/class_388 com/lunar/common/mod/skyblockaddons/SkyblockAddonsSummoningEyeCounterChildMod
+	FIELD field_1358 textColor Lcom/lunar/class_561;
+	FIELD field_1359 summoningEyeIconResource Lcom/lunar/class_245;
+	FIELD field_1360 showTextShadow Lcom/lunar/class_574;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsTickerChargesChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsTickerChargesChildMod.mapping
@@ -1,0 +1,4 @@
+CLASS com/lunar/class_396 com/lunar/common/mod/skyblockaddons/SkyblockAddonsTickerChargesChildMod
+	FIELD field_1422 tickerIconResource Lcom/lunar/class_245;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsWarningsChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsWarningsChildMod.mapping
@@ -1,0 +1,23 @@
+CLASS com/lunar/class_391 com/lunar/common/mod/skyblockaddons/SkyblockAddonsWarningsChildMod
+	FIELD field_1363 warningTime Lcom/lunar/class_560;
+	FIELD field_1364 warnOnMagmaBoss Lcom/lunar/class_574;
+	FIELD field_1365 warnOnFullMinion Lcom/lunar/class_574;
+	FIELD field_1366 shadowColor Lcom/lunar/class_561;
+	FIELD field_1367 warnOnMinionLocationDisable Lcom/lunar/class_574;
+	FIELD field_1371 repeatFullInventoryWarning Lcom/lunar/class_574;
+	FIELD field_1372 warnOnFullInventory Lcom/lunar/class_574;
+	FIELD field_1373 textColor Lcom/lunar/class_561;
+	FIELD field_1374 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1375 warnOnMinionStop Lcom/lunar/class_574;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba
+	METHOD method_1166 warnsOnMinionStop ()Lcom/lunar/class_574;
+	METHOD method_1167 getTextColor ()Lcom/lunar/class_561;
+	METHOD method_1168 warnsOnMinionLocationDisable ()Lcom/lunar/class_574;
+	METHOD method_1172 getWarningTime ()Lcom/lunar/class_560;
+	METHOD method_1173 warnsOnMagmaBoss ()Lcom/lunar/class_574;
+	METHOD method_1174 warnsOnFullMinion ()Lcom/lunar/class_574;
+	METHOD method_1175 warnsOnFullInventory ()Lcom/lunar/class_574;
+	METHOD method_1176 getShadowColor ()Lcom/lunar/class_561;
+	METHOD method_1177 showsTextShadow ()Lcom/lunar/class_574;
+	METHOD method_1180 repeatsFullInventroyWarning ()Lcom/lunar/class_574;

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotKillsChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotKillsChildMod.mapping
@@ -1,0 +1,6 @@
+CLASS com/lunar/class_380 com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotKillsChildMod
+	FIELD field_1390 textColor Lcom/lunar/class_561;
+	FIELD field_1391 endermanIconResource Lcom/lunar/class_245;
+	FIELD field_1392 showTextShadow Lcom/lunar/class_574;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotPerEyeMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotPerEyeMod.mapping
@@ -1,1 +1,0 @@
-CLASS com/lunar/class_383 com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotPerEyeMod

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotTotalCounterChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotTotalCounterChildMod.mapping
@@ -1,0 +1,6 @@
+CLASS com/lunar/class_394 com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotTotalCounterChildMod
+	FIELD field_1387 textColor Lcom/lunar/class_561;
+	FIELD field_1388 endermanGroupIconResource Lcom/lunar/class_245;
+	FIELD field_1389 showTextShadow Lcom/lunar/class_574;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotsPerEyeChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotsPerEyeChildMod.mapping
@@ -1,0 +1,7 @@
+CLASS com/lunar/class_383 com/lunar/common/mod/skyblockaddons/SkyblockAddonsZealotsPerEyeChildMod
+	FIELD field_1383 showTextShadow Lcom/lunar/class_574;
+	FIELD field_1384 slashResource Lcom/lunar/class_245;
+	FIELD field_1385 zealotsPerEyeIconResource Lcom/lunar/class_245;
+	FIELD field_1386 textColor Lcom/lunar/class_561;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba

--- a/mappings/com/lunar/common/mod/skyblockaddons/ZealotTotalCounterMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/ZealotTotalCounterMod.mapping
@@ -1,1 +1,0 @@
-CLASS com/lunar/class_394 com/lunar/common/mod/skyblockaddons/ZealotTotalCounterMod

--- a/mappings/com/lunar/common/mod/skyblockaddons/skyBlockAddonsManaBarChildMod.mapping
+++ b/mappings/com/lunar/common/mod/skyblockaddons/skyBlockAddonsManaBarChildMod.mapping
@@ -1,1 +1,5 @@
-CLASS com/lunar/class_385 com/lunar/common/mod/skyblockaddons/skyBlockAddonsManaBarChildMod
+CLASS com/lunar/class_385 com/lunar/common/mod/skyblockaddons/SkyblockAddonsManaBarChildMod
+	FIELD field_1407 barColor Lcom/lunar/class_561;
+	FIELD field_1408 barResource Lcom/lunar/class_245;
+	METHOD <init> (Lcom/lunar/class_195;)V
+		ARG 1 sba


### PR DESCRIPTION
Some stuff:

- I renamed a lot of stuff "SkyBlock" -> "Skyblock" because the GitHub repo is "SkyblockAddons" so it must be the correct spelling.
- I standardize a naming convention of "SkyblockAddons(feature name)ChildMod". Should be simple enough.
- That's about it.